### PR TITLE
resource_redirect/create: Explicitly disable 'merge' functionality.

### DIFF
--- a/internal/provider/resource_redirect.go
+++ b/internal/provider/resource_redirect.go
@@ -5,13 +5,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"io"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -113,6 +113,8 @@ func redirectTypeValidator(i interface{}, _ cty.Path) diag.Diagnostics {
 // https://redirect.pizza/docs#tag/Redirects/operation/createRedirect
 func resourceRedirectCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	data := hydrateHttpPersistData(d)
+	merge := false // Do not use the merge functionality for resources managed by Terraform
+	data.Merge = &merge
 	reqBody, _ := json.Marshal(data)
 
 	apiClientData := meta.(*apiClient)
@@ -264,6 +266,7 @@ type httpPersistData struct {
 	KeepQueryString bool     `json:"keep_query_string"`
 	Tracking        bool     `json:"tracking"`
 	Tags            []string `json:"tags"`
+	Merge           *bool    `json:"merge,omitempty"`
 }
 
 func hydrateHttpPersistData(d *schema.ResourceData) *httpPersistData {


### PR DESCRIPTION
This way, new resources will be solely managed by TerraForm and not be ('accidentally') rolled up into other pre-existing redirects which may or may not be managed outside of Terraform